### PR TITLE
Update Deploy-Policies.ps1

### DIFF
--- a/Deploy-Policies.ps1
+++ b/Deploy-Policies.ps1
@@ -128,7 +128,7 @@ if($Endpoint -eq "Beta"){
     Select-MgProfile -Name "beta"
 }
 try{Disconnect-MgGraph -ErrorAction SilentlyContinue}catch{}
-Connect-MgGraph -Scopes "Policy.ReadWrite.ConditionalAccess","Group.ReadWrite.All" -ErrorAction Stop
+Connect-MgGraph -Scopes "Application.Read.All","Group.ReadWrite.All","Policy.Read.All","Policy.ReadWrite.ConditionalAccess" -ErrorAction Stop
 #endregion
 
 #region parameters


### PR DESCRIPTION
Adding required scope permissions for graph access. While testing on a new tenant was unable to deploy without these additional permissions.