### PR TITLE
Add EmergencyAccessAccountsGroup replacement includeGroups

### DIFF
--- a/Deploy-Policies.ps1
+++ b/Deploy-Policies.ps1
@@ -329,6 +329,12 @@ foreach ($Policy in $Policies) {
             $includeGroups.Remove("<AdministratorGroup>") > $null
         }
 
+        #Replace Conditional_Access_Exclusion_EmergencyAccessAccounts
+        if ($includeGroups.Contains("<EmergencyAccessAccountsGroup>")) {
+            $includeGroups.Add($ObjectID_EmergencyAccessAccounts) > $null
+            $includeGroups.Remove("<EmergencyAccessAccountsGroup>") > $null
+        }
+
         $Policy.conditions.users.includeGroups = $includeGroups
     }
 


### PR DESCRIPTION
CA 110 - <RING> - Admin protection - All apps: Require MFA For BreakGlassAccount has the EmergencyAccessAccountsGroup in includedgroups and this is not covered in the region of the replacements. Add this replace.
I hope you find it useful. In my case it does the job properly.

As it's my very first public contribution any suggestions to improve code quality or whatever are very much appreciated. :)